### PR TITLE
Don't init storage_cache array

### DIFF
--- a/includes/polling/storage.inc.php
+++ b/includes/polling/storage.inc.php
@@ -2,8 +2,6 @@
 
 use LibreNMS\RRD\RrdDefinition;
 
-$storage_cache = array();
-
 foreach (dbFetchRows('SELECT * FROM storage WHERE device_id = ?', array($device['device_id'])) as $storage) {
     $descr = $storage['storage_descr'];
     $mib = $storage['storage_mib'];


### PR DESCRIPTION
This array has already been init in the mempools polling.
Be deleting this init, we use the $storage_cache array  populated by mempools polling, so we bypass a new snmp call.
This not just a optimisation, this also resolve issue with some WINDOWS (it timeout the second time we call hrstorage in a few second) like in #4929

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
